### PR TITLE
use html5 doctype to avoid "limited quirks mode"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+<!doctype html>
+
 <body>
 </body>
 <script>


### PR DESCRIPTION
This PR adds the standard html5 doctype to the `index.html`. 

It fixes the display of patchwork-next styles and avoids needing to remove `flex: 1` from the stylesheets. It also makes css classes case sensitive among many other "modern" things. Basically, everything is bizarrely broken without it. 

see https://hsivonen.fi/doctype/ for more info

_Thanks_ "the past".