### PR TITLE
remove two weird logs and fix an undefined error

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,6 @@ app.on('ready', function next () {
   // and load the index.html of the app.
 
 //  require('assert').deepEqual(qs.parse(qs.stringify(proc)), proc)
-  console.log(mainWindow)
   mainWindow.loadURL('file://' + path.join(__dirname, 'index.html') + '?' +
     encodeURIComponent(qs.stringify(proc)));
 
@@ -66,7 +65,6 @@ app.on('ready', function next () {
       .resume()
 
     var ipc = electron.ipcMain //require('ipc')
-  console.log(electron)
     ipc.on('process.stdout', function (s, data) {
       process.stdout.write(new Buffer(data, 'base64'))
     })

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ app.on('ready', function next () {
   mainWindow.webContents.on('new-window', function (e, url) {
     // open in the browser
     e.preventDefault()
-    shell.openExternal(url)
+    electron.shell.openExternal(url)
   })
 
   // Open the devtools.


### PR DESCRIPTION
there is no `shell` variable in scope, has to be `electron.shell`.

Given that this was broken for so long it might make more sense to remove the handler alltogether? patchbay hooks it itself for instance.

see ssbc/patchbay#157